### PR TITLE
[Caldera] Filling out technique ID value

### DIFF
--- a/data/abilities/detection/13d0d9cf-e31a-47b6-9217-f38e3f7c25ef.yml
+++ b/data/abilities/detection/13d0d9cf-e31a-47b6-9217-f38e3f7c25ef.yml
@@ -5,7 +5,7 @@
   description: Collect system information from Sysmon event log given ProcessGUID. Ability timeout may need to be increased depending on Sysmon log size.
   tactic: detection
   technique:
-    attack_id:
+    attack_id: x
     name: Query Event Logs
   platforms:
     windows:

--- a/data/abilities/detection/90418255-b202-4fc3-b0ea-b105bff39ca5.yml
+++ b/data/abilities/detection/90418255-b202-4fc3-b0ea-b105bff39ca5.yml
@@ -5,7 +5,7 @@
   description: Collect Sysmon ProcessGUIDs from given ProcessID
   tactic: detection
   technique:
-    attack_id:
+    attack_id: x
     name: Query Event Logs
   platforms:
     windows:


### PR DESCRIPTION
Adding at least something to the `attack_id` field removes the WARNING message on the Caldera side:

```
(data_svc.py:347 _verify_ability_set) Fix technique ID for ability: 13d0d9cf-e31a-47b6-9217-f38e3f7c25ef
(data_svc.py:347 _verify_ability_set) Fix technique ID for ability: 90418255-b202-4fc3-b0ea-b105bff39ca5
```

More information in this issue:
https://github.com/mitre/caldera/issues/1480