### PR TITLE
VIRTS-1062/reordering adversaries for new planner structure

### DIFF
--- a/data/adversaries/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
+++ b/data/adversaries/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
@@ -1,11 +1,9 @@
 id: 7e422753-ad7a-4401-bc8b-b12a28e69c25
 name: Incident responder
 description: A basic incident responder profile
-phases:
-  1:
+atomic_ordering:
     - 3b4640bc-eacb-407a-a997-105e39788781
     - 1b4aa8d5-ba97-4b9b-92a3-eaaaffbfdf0a
-  2:
     - 02fb7fa9-8886-4330-9e65-fa7bb1bc5271
     - debd322d-2100-45f7-8832-29ef7c56786d
     - cb85039a-6196-4262-883b-0beeb804b83d

--- a/data/adversaries/f61e3fc0-43d8-4b36-b5d3-710610b92974.yml
+++ b/data/adversaries/f61e3fc0-43d8-4b36-b5d3-710610b92974.yml
@@ -1,8 +1,6 @@
 description: Collect system information given a process ID by querying Sysmon event log
 id: f61e3fc0-43d8-4b36-b5d3-710610b92974
 name: Query Sysmon
-phases:
-  1:
+atomic_ordering:
   - 90418255-b202-4fc3-b0ea-b105bff39ca5
-  2:
   - 13d0d9cf-e31a-47b6-9217-f38e3f7c25ef


### PR DESCRIPTION
- Adversaries use `atomic_ordering` versus `phases`