### PR TITLE
relationship objects removed from requirements

### DIFF
--- a/app/requirements/base_requirement.py
+++ b/app/requirements/base_requirement.py
@@ -12,7 +12,7 @@ class BaseRequirement:
         """
         if not self._check_edge(relationship.edge):
             return False
-        if self.enforcements.target:
+        if 'target' in self.enforcements.keys():
             for fact in used_facts:
                 if self._check_target(relationship.target, fact):
                     return True
@@ -32,6 +32,6 @@ class BaseRequirement:
         return False
 
     def _check_edge(self, edge):
-        if edge == self.enforcements.edge:
+        if edge == self.enforcements['edge']:
             return True
         return False

--- a/app/requirements/basic.py
+++ b/app/requirements/basic.py
@@ -8,12 +8,12 @@ class Requirement(BaseRequirement):
         Given a link and the current operation, check if the link's used fact combination complies
         with the abilities enforcement mechanism
         :param link
-        :param relationships
+        :param operation
         :return: True if it complies, False if it doesn't
         """
         relationships = operation.all_relationships()
         for uf in link.used:
-            if self.enforcements.source == uf.trait:
+            if self.enforcements['source'] == uf.trait:
                 for r in self._get_relationships(uf, relationships):
                     if self.is_valid_relationship([f for f in link.used if f != uf], r):
                         return True


### PR DESCRIPTION
New schema changes to Requirement where Requirements no longer use Relationship objects for requirement enforcement