### PR TITLE
Silently continuing on error

### DIFF
--- a/data/abilities/detection/3b4640bc-eacb-407a-a997-105e39788781.yml
+++ b/data/abilities/detection/3b4640bc-eacb-407a-a997-105e39788781.yml
@@ -29,7 +29,7 @@
     windows:
       psh,pwsh:
         command: |
-          Get-NetTCPConnection -RemotePort "#{remote.port.unauthorized}" | where-object { write-host $_.OwningProcess }
+          Get-NetTCPConnection -RemotePort "#{remote.port.unauthorized}" -EA silentlycontinue | where-object { write-host $_.OwningProcess }
         parsers:
           plugins.response.app.parsers.process:
             - source: remote.port.unauthorized


### PR DESCRIPTION
The powershell command produces an error when no processes are found on the port. This changes silences that error.