### PR TITLE
VIRTS 1262 improved auto collect

### DIFF
--- a/data/abilities/response/13d0d9cf-e31a-47b6-9217-f38e3f7c25ef.yml
+++ b/data/abilities/response/13d0d9cf-e31a-47b6-9217-f38e3f7c25ef.yml
@@ -13,7 +13,7 @@
         timeout: 300
         command: |
           $Yesterday = (Get-Date) - (New-TimeSpan -Day 1);
-          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday } | select TimeCreated,Id,ProviderName,RecordId,ProcessId,MachineName,Message | where -Property Message -Match "\bProcessGuid: {#{host.process.guid}}" | Format-List;
+          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday; Id=1 } | select TimeCreated,Id,ProviderName,RecordId,ProcessId,MachineName,Message | where -Property Message -Match "\bProcessGuid: {#{host.process.guid}}" | Format-List;
         parsers:
           plugins.response.app.parsers.sysmon:
             - source: host.process.guid
@@ -28,7 +28,7 @@
       cmd:
         timeout: 300
         command: |
-          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */EventData/Data[@Name='ProcessGuid']='#{host.process.guid}'" /f:text
+          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */System/EventID=1 and */EventData/Data[@Name='ProcessGuid']='#{host.process.guid}'" /f:text
         parsers:
           plugins.response.app.parsers.sysmon:
             - source: host.process.guid

--- a/data/abilities/response/13d0d9cf-e31a-47b6-9217-f38e3f7c25ef.yml
+++ b/data/abilities/response/13d0d9cf-e31a-47b6-9217-f38e3f7c25ef.yml
@@ -13,7 +13,7 @@
         timeout: 300
         command: |
           $Yesterday = (Get-Date) - (New-TimeSpan -Day 1);
-          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday; Id=1 } | select TimeCreated,Id,ProviderName,RecordId,ProcessId,MachineName,Message | where -Property Message -Match "\bProcessGuid: {#{host.process.guid}}" | Format-List;
+          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday; } | select TimeCreated,Id,ProviderName,RecordId,ProcessId,MachineName,Message | where -Property Message -Match "\bProcessGuid: {#{host.process.guid}}" | Format-List;
         parsers:
           plugins.response.app.parsers.sysmon:
             - source: host.process.guid
@@ -28,7 +28,7 @@
       cmd:
         timeout: 300
         command: |
-          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */System/EventID=1 and */EventData/Data[@Name='ProcessGuid']='#{host.process.guid}'" /f:text
+          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */EventData/Data[@Name='ProcessGuid']='#{host.process.guid}'" /f:text
         parsers:
           plugins.response.app.parsers.sysmon:
             - source: host.process.guid

--- a/data/abilities/response/2331077e-7be9-4e89-b2bb-32e8d7f6a708.yml
+++ b/data/abilities/response/2331077e-7be9-4e89-b2bb-32e8d7f6a708.yml
@@ -1,0 +1,20 @@
+---
+
+- id: 2331077e-7be9-4e89-b2bb-32e8d7f6a708
+  name: Collect Parent's Child Proccesses
+  description: Collect all process creation events with the given parent process GUID
+  tactic: response
+  technique:
+    attack_id: x
+    name: Query Event Logs
+  platforms:
+    windows:
+      psh:
+        timeout: 300
+        command: |
+          $Yesterday = (Get-Date) - (New-TimeSpan -Day 1);
+          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday; Id=1 } | where -Property Message -Match "\bParentProcessGuid: {#{host.process.parentguid}}" | Format-List;
+      cmd:
+        timeout: 300
+        command: |
+          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */System/EventID=1 and */EventData/Data[@Name='ParentProcessGuid']='#{host.process.parentguid}'" /f:text

--- a/data/abilities/response/90418255-b202-4fc3-b0ea-b105bff39ca5.yml
+++ b/data/abilities/response/90418255-b202-4fc3-b0ea-b105bff39ca5.yml
@@ -2,7 +2,7 @@
 
 - id: 90418255-b202-4fc3-b0ea-b105bff39ca5
   name: Collect GUID from PID
-  description: Collect Sysmon ProcessGUIDs from given ProcessID
+  description: Collect process GUIDs by querying Sysmon for all process creation events associated with the given PID or whose parent PID is the given PID
   tactic: response
   technique:
     attack_id: x
@@ -12,17 +12,29 @@
       psh:
         command: |
           $Yesterday = (Get-Date) - (New-TimeSpan -Day 1);
-          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday } | where -Property Message -Match '(?m)^[Parent]*ProcessId: #{host.process.id}\b' | Format-List;
+          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday; Id=1 } | where -Property Message -Match '(?m)^[Parent]*ProcessId: #{host.process.id}\b' | Format-List;
         parsers:
           plugins.response.app.parsers.processguids:
             - source: host.process.id
               edge: has_guid
               target: host.process.guid
+            - source: host.process.guid
+              edge: has_parentid
+              target: host.process.parentid
+            - source: host.process.parentid
+              edge: has_guid
+              target: host.process.parentguid
       cmd:
         command: |
-          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */EventData/Data[@Name='ProcessId']=#{host.process.id} or */EventData/Data[@Name='ParentProcessId']=#{host.process.id}" /f:text
+          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */System/EventID=1 and */EventData/Data[@Name='ProcessId']=#{host.process.id} or */EventData/Data[@Name='ParentProcessId']=#{host.process.id}" /f:text
         parsers:
           plugins.response.app.parsers.processguids:
             - source: host.process.id
               edge: has_guid
               target: host.process.guid
+            - source: host.process.guid
+              edge: has_parentid
+              target: host.process.parentid
+            - source: host.process.parentid
+              edge: has_guid
+              target: host.process.parentguid

--- a/data/abilities/response/90418255-b202-4fc3-b0ea-b105bff39ca5.yml
+++ b/data/abilities/response/90418255-b202-4fc3-b0ea-b105bff39ca5.yml
@@ -2,7 +2,7 @@
 
 - id: 90418255-b202-4fc3-b0ea-b105bff39ca5
   name: Collect GUID from PID
-  description: Collect process GUIDs by querying Sysmon for all process creation events associated with the given PID or whose parent PID is the given PID
+  description: Collect process GUIDs by querying Sysmon for all events associated with the given PID or whose parent PID is the given PID
   tactic: response
   technique:
     attack_id: x
@@ -12,7 +12,7 @@
       psh:
         command: |
           $Yesterday = (Get-Date) - (New-TimeSpan -Day 1);
-          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday; Id=1 } | where -Property Message -Match '(?m)^[Parent]*ProcessId: #{host.process.id}\b' | Format-List;
+          Get-WinEvent -FilterHashTable @{ Logname='Microsoft-Windows-Sysmon/Operational'; StartTime=$Yesterday;} | where -Property Message -Match '(?m)^[Parent]*ProcessId: #{host.process.id}\b' | Format-List;
         parsers:
           plugins.response.app.parsers.processguids:
             - source: host.process.id
@@ -26,7 +26,7 @@
               target: host.process.parentguid
       cmd:
         command: |
-          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */System/EventID=1 and */EventData/Data[@Name='ProcessId']=#{host.process.id} or */EventData/Data[@Name='ParentProcessId']=#{host.process.id}" /f:text
+          wevtutil qe Microsoft-Windows-Sysmon/Operational /q:"*/System/TimeCreated[timediff(@SystemTime) <= 86400000] and */EventData/Data[@Name='ProcessId']=#{host.process.id} or */EventData/Data[@Name='ParentProcessId']=#{host.process.id}" /f:text
         parsers:
           plugins.response.app.parsers.processguids:
             - source: host.process.id

--- a/data/adversaries/f61e3fc0-43d8-4b36-b5d3-710610b92974.yml
+++ b/data/adversaries/f61e3fc0-43d8-4b36-b5d3-710610b92974.yml
@@ -4,3 +4,4 @@ name: Query Sysmon
 atomic_ordering:
   - 90418255-b202-4fc3-b0ea-b105bff39ca5
   - 13d0d9cf-e31a-47b6-9217-f38e3f7c25ef
+  - 2331077e-7be9-4e89-b2bb-32e8d7f6a708


### PR DESCRIPTION
- New ability added to the Query Sysmon profile that queries sysmon for any process creation events with the given parent GUID. Effectively looks for all of the child processes spawned by the parent
- Filtering the returned ability facts in response_svc to (1) only run the System Info from GUID on GUIDs that directly belong to the red agent's PID and (2) only run Collect Parent's Child Processes on the GUID associated with the red agent process. Effectively reduces the number of links (queries) run by the auto-collector to only queries related to red agent child processes.