### PR TITLE
elasticsearch threat hunting

### DIFF
--- a/app/parsers/ecs_sysmon.py
+++ b/app/parsers/ecs_sysmon.py
@@ -14,7 +14,15 @@ class Parser(BaseParser):
 
     def parse(self, blob):
         relationships = []
-        for event in json.loads(blob):
+        loaded = json.loads(blob)
+
+        # Do not parse facts, if the result is an array (multiple results returned).
+        # This prevents facts from being parsed when results are directly returned from elasticat,
+        # allowing them to be parsed and added to pseudo-links created for the results.  This
+        # restriction is present because a fact can not exist on more than one link in an operation at
+        # a time.
+        if isinstance(loaded, dict):
+            event = loaded
             for mp in self.mappers:
                 match = self.parse_options[mp.target.split('.').pop()](event)
                 if match:

--- a/app/parsers/ecs_sysmon.py
+++ b/app/parsers/ecs_sysmon.py
@@ -1,0 +1,55 @@
+import json
+
+from app.objects.secondclass.c_fact import Fact
+from app.objects.secondclass.c_relationship import Relationship
+from app.utility.base_parser import BaseParser
+
+
+class Parser(BaseParser):
+    """
+    This parser extracts information from sysmon events that
+     have been transformed via the Elastic Common Schema (ECS)
+    JSON documents (REF: https://www.elastic.co/guide/en/ecs/current/ecs-field-reference.html).
+    """
+
+    def parse(self, blob):
+        relationships = []
+        for event in json.loads(blob):
+            for mp in self.mappers:
+                match = self.parse_options[mp.target.split('.').pop()](event)
+                if match:
+                    guid = self.parse_process_guid(event)
+                    relationships.append(Relationship(source=Fact(mp.source, guid),
+                                                      edge=mp.edge,
+                                                      target=Fact(mp.target, match)))
+        return relationships
+
+    @property
+    def parse_options(self):
+        return dict(
+            eventid=self.parse_eventid,
+            recordid=self.parse_recordid,
+            user=self.parse_user,
+            guid=self.parse_process_guid,
+            pid=self.parse_pid,
+        )
+
+    @staticmethod
+    def parse_process_guid(event):
+        return event['_source']['process']['entity_id']
+
+    @staticmethod
+    def parse_eventid(event):
+        return event['_source']['winlog']['event_id']
+
+    @staticmethod
+    def parse_recordid(event):
+        return event['_source']['winlog']['record_id']
+
+    @staticmethod
+    def parse_user(event):
+        return "%s\\%s" % (event['_source']['user']['domain'], event['_source']['user']['name'])
+
+    @staticmethod
+    def parse_pid(event):
+        return event['_source']['process']['pid']

--- a/app/parsers/ecs_sysmon.py
+++ b/app/parsers/ecs_sysmon.py
@@ -16,7 +16,7 @@ class Parser(BaseParser):
         relationships = []
         loaded = json.loads(blob)
 
-        # Do not parse facts, if the result is an array (multiple results returned).
+        # Do not parse facts if the result is an array (multiple results returned).
         # This prevents facts from being parsed when results are directly returned from elasticat,
         # allowing them to be parsed and added to pseudo-links created for the results.  This
         # restriction is present because a fact can not exist on more than one link in an operation at

--- a/app/response_svc.py
+++ b/app/response_svc.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from app.objects.secondclass.c_fact import Fact
 from app.objects.c_operation import Operation
 from app.objects.c_source import Source
-from app.objects.secondclass.c_link import Link
 from app.objects.secondclass.c_result import Result
 from app.utility.base_service import BaseService
 

--- a/data/abilities/command-and-control/1837b43e-4fff-46b2-a604-a602f7540469.yaml
+++ b/data/abilities/command-and-control/1837b43e-4fff-46b2-a604-a602f7540469.yaml
@@ -1,0 +1,40 @@
+- id: 1837b43e-4fff-46b2-a604-a602f7540469
+  name: Elasticat
+  description: A Blue Python agent that executes elasticsearch queries.
+  tactic: command-and-control
+  technique:
+    attack_id: T1071
+    name: Standard Application Layer Protocol
+  platforms:
+    darwin:
+      sh:
+        command: |
+          server="#{app.contact.http}";
+          curl -s -X POST -H "file:elasticat.py" -H "platform:darwin" $server/file/download > elasticat.py;
+          pip install requests;
+          python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
+        variations:
+          - description: Executes elasticsearch queries and returns results via HTTP.
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:elasticat.py" -H "platform:darwin" $server/file/download > elasticat.py;
+              pip install requests;
+              python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
+        cleanup: |
+          pkill -f elasticat
+    linux:
+      sh:
+        command: |
+          server="#{app.contact.http}";
+          curl -s -X POST -H "file:elasticat.py" -H "platform:linux" $server/file/download > elasticat.py;
+          pip install requests;
+          python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
+        variations:
+          - description: Executes elasticsearch queries and returns results via HTTP.
+            command: |
+              server="#{app.contact.http}";
+              curl -s -X POST -H "file:elasticat.py" -H "platform:darwin" $server/file/download > elasticat.py;
+              pip install requests;
+              python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
+        cleanup: |
+          pkill -f elaticat

--- a/data/abilities/command-and-control/1837b43e-4fff-46b2-a604-a602f7540469.yaml
+++ b/data/abilities/command-and-control/1837b43e-4fff-46b2-a604-a602f7540469.yaml
@@ -8,33 +8,25 @@
   platforms:
     darwin:
       sh:
-        command: |
+        command: &darwin_launch_cmd |
           server="#{app.contact.http}";
           curl -s -X POST -H "file:elasticat.py" -H "platform:darwin" $server/file/download > elasticat.py;
           pip install requests;
           python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
         variations:
           - description: Executes elasticsearch queries and returns results via HTTP.
-            command: |
-              server="#{app.contact.http}";
-              curl -s -X POST -H "file:elasticat.py" -H "platform:darwin" $server/file/download > elasticat.py;
-              pip install requests;
-              python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
+            command: *darwin_launch_cmd
         cleanup: |
           pkill -f elasticat
     linux:
       sh:
-        command: |
+        command: &linux_launc_cmd |
           server="#{app.contact.http}";
           curl -s -X POST -H "file:elasticat.py" -H "platform:linux" $server/file/download > elasticat.py;
           pip install requests;
           python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
         variations:
           - description: Executes elasticsearch queries and returns results via HTTP.
-            command: |
-              server="#{app.contact.http}";
-              curl -s -X POST -H "file:elasticat.py" -H "platform:darwin" $server/file/download > elasticat.py;
-              pip install requests;
-              python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
+            command: *linux_launc_cmd
         cleanup: |
           pkill -f elaticat

--- a/data/abilities/command-and-control/1837b43e-4fff-46b2-a604-a602f7540469.yml
+++ b/data/abilities/command-and-control/1837b43e-4fff-46b2-a604-a602f7540469.yml
@@ -8,25 +8,19 @@
   platforms:
     darwin:
       sh:
-        command: &darwin_launch_cmd |
+        command: |
           server="#{app.contact.http}";
           curl -s -X POST -H "file:elasticat.py" -H "platform:darwin" $server/file/download > elasticat.py;
           pip install requests;
           python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
-        variations:
-          - description: Executes elasticsearch queries and returns results via HTTP.
-            command: *darwin_launch_cmd
         cleanup: |
           pkill -f elasticat
     linux:
       sh:
-        command: &linux_launc_cmd |
+        command: |
           server="#{app.contact.http}";
           curl -s -X POST -H "file:elasticat.py" -H "platform:linux" $server/file/download > elasticat.py;
           pip install requests;
           python elasticat.py --server=$server --es-host="http://127.0.0.1:9200" --group=blue --minutes-since=60
-        variations:
-          - description: Executes elasticsearch queries and returns results via HTTP.
-            command: *linux_launc_cmd
         cleanup: |
           pkill -f elaticat

--- a/data/abilities/elastic_hunting/4b283acc-45c0-4de8-b0ac-ac0699e5ab95.yml
+++ b/data/abilities/elastic_hunting/4b283acc-45c0-4de8-b0ac-ac0699e5ab95.yml
@@ -11,6 +11,20 @@
       elasticsearch: &cmd
         command: |
           process.name:powershell.exe AND process.args:*Bypass* AND process.args:*ExecutionPolicy*
+        parsers:
+          plugins.response.app.parsers.ecs_sysmon:
+            - source: host.process.guid
+              edge: has_eventid
+              target: host.process.eventid
+            - source: host.process.guid
+              edge: has_recordid
+              target: host.process.recordid
+            - source: host.process.guid
+              edge: has_user
+              target: host.process.user
+            - source: host.process.guid
+              edge: has_pid
+              target: host.unauthorized.pid
     linux:
       elasticsearch:
         *cmd

--- a/data/abilities/elastic_hunting/4b283acc-45c0-4de8-b0ac-ac0699e5ab95.yml
+++ b/data/abilities/elastic_hunting/4b283acc-45c0-4de8-b0ac-ac0699e5ab95.yml
@@ -1,0 +1,19 @@
+---
+- id: 4b283acc-45c0-4de8-b0ac-ac0699e5ab95
+  name: Search for PowerShell ExecutionPolicy Bypass (elastic)
+  description: Search for Sysmon Event 1 powershell records with "ExecutionPolicy" and "Bypass"
+  tactic: hunt
+  technique:
+    attack_id: x
+    name: x
+  platforms:
+    windows:
+      elasticsearch: &cmd
+        command: |
+          process.name:powershell.exe AND process.args:*Bypass* AND process.args:*ExecutionPolicy*
+    linux:
+      elasticsearch:
+        *cmd
+    darwin:
+      elasticsearch:
+        *cmd

--- a/data/adversaries/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
+++ b/data/adversaries/7e422753-ad7a-4401-bc8b-b12a28e69c25.yml
@@ -12,3 +12,4 @@ atomic_ordering:
     - cb85039a-6196-4262-883b-0beeb804b83d
     - 5ec7ae3b-c909-41bb-9b6b-dadec409cd40
     - 2ca64acd-dc12-4cc8-b78a-6a182508a50b
+    - 4b283acc-45c0-4de8-b0ac-ac0699e5ab95

--- a/hook.py
+++ b/hook.py
@@ -14,4 +14,8 @@ async def enable(services):
     app.router.add_route('GET', '/plugin/responder/gui', response_svc.splash)
     app.router.add_route('POST', '/plugin/responder/update', response_svc.update_responder)
 
+    agents = BaseWorld.get_config(name='agents', prop='deployments')
+    agents.append('1837b43e-4fff-46b2-a604-a602f7540469')  # Elasticat agent
+    BaseWorld.set_config(name='agents', prop='deployments', value=agents)
+
     await response_svc.register_handler(services.get('event_svc'))

--- a/hook.py
+++ b/hook.py
@@ -14,8 +14,8 @@ async def enable(services):
     app.router.add_route('GET', '/plugin/responder/gui', response_svc.splash)
     app.router.add_route('POST', '/plugin/responder/update', response_svc.update_responder)
 
-    agents = BaseWorld.get_config(name='agents', prop='deployments')
-    agents.append('1837b43e-4fff-46b2-a604-a602f7540469')  # Elasticat agent
-    BaseWorld.set_config(name='agents', prop='deployments', value=agents)
+    agents = set(BaseWorld.get_config(name='agents', prop='deployments'))
+    agents.add('1837b43e-4fff-46b2-a604-a602f7540469')  # Elasticat agent
+    BaseWorld.set_config(name='agents', prop='deployments', value=list(agents))
 
     await response_svc.register_handler(services.get('event_svc'))

--- a/hook.py
+++ b/hook.py
@@ -14,8 +14,16 @@ async def enable(services):
     app.router.add_route('GET', '/plugin/responder/gui', response_svc.splash)
     app.router.add_route('POST', '/plugin/responder/update', response_svc.update_responder)
 
-    agents = set(BaseWorld.get_config(name='agents', prop='deployments'))
-    agents.add('1837b43e-4fff-46b2-a604-a602f7540469')  # Elasticat agent
-    BaseWorld.set_config(name='agents', prop='deployments', value=list(agents))
+    _register_agent('1837b43e-4fff-46b2-a604-a602f7540469')  # Elasticat agent
 
     await response_svc.register_handler(services.get('event_svc'))
+
+
+def _register_agent(ability_id):
+    """
+    Registers an agent with caldera -- the agent's launch commands and variations
+     will be displayed in the 'Deploy Agent' modal of the web interface.
+    """
+    agents = set(BaseWorld.get_config(name='agents', prop='deployments'))
+    agents.add(ability_id)
+    BaseWorld.set_config(name='agents', prop='deployments', value=list(agents))

--- a/payloads/elasticat.py
+++ b/payloads/elasticat.py
@@ -14,11 +14,12 @@ import requests
 class OperationLoop:
 
     def __init__(self, server, es_host='http://127.0.0.1:9200', index_pattern='*',
-                 result_size=10, group='blue', minutes_since=60):
+                 result_size=10, group='blue', minutes_since=60, sleep=60):
         self.es_host = es_host
         self.index_pattern = index_pattern
         self.result_size = result_size
         self.minutes_since = minutes_since
+        self.sleep = sleep
         self._profile = dict(
             server=server,
             host=socket.gethostname(),
@@ -53,8 +54,8 @@ class OperationLoop:
             try:
                 print('[*] Sending beacon for %s' % (self.paw,))
                 beacon = self._send_beacon()
-                sleep = self._handle_instructions(beacon)
-                time.sleep(sleep)
+                self.sleep = self._handle_instructions(beacon)
+                time.sleep(self.sleep)
             except Exception as e:
                 print('[-] Operation loop error: %s' % e)
                 traceback.print_exc()
@@ -108,9 +109,11 @@ if __name__ == '__main__':
     parser.add_argument('--group', default='blue')
     parser.add_argument('--minutes-since', dest='minutes_since', default=60, type=int,
                         help='How many minutes back to search for events.')
+    parser.add_argument('--sleep', default=60, type=int,
+                        help='Number of seconds to wait to check for new commands.')
     args = parser.parse_args()
     try:
         OperationLoop(args.server, es_host=args.es_host, index_pattern=args.index, group=args.group,
-                      minutes_since=args.minutes_since).start()
+                      minutes_since=args.minutes_since, sleep=args.sleep).start()
     except Exception as e:
         print('[-] Caldera server not be accessible, or: %s' % e)

--- a/payloads/elasticat.py
+++ b/payloads/elasticat.py
@@ -1,0 +1,117 @@
+import argparse
+import copy
+import json
+import os
+import platform
+import subprocess
+import socket
+import time
+import traceback
+from base64 import b64encode, b64decode
+
+import requests
+
+
+class OperationLoop:
+
+    def __init__(self, server, es_host='http://127.0.0.1:9200', index_pattern='*',
+                 result_size=10, group='blue', minutes_since=60):
+        self.es_host = es_host
+        self.index_pattern = index_pattern
+        self.result_size = result_size
+        self.minutes_since = minutes_since
+        self._profile = dict(
+            server=server,
+            host=socket.gethostname(),
+            platform=platform.system().lower(),
+            executors=['elasticsearch'],
+            pid=os.getpid(),
+            group=group
+        )
+
+    def get_profile(self):
+        return copy.copy(self._profile)
+
+    @property
+    def server(self):
+        return self._profile['server']
+
+    @property
+    def paw(self):
+        return self._profile.get('paw', 'unknown')
+
+    def execute_lucene_query(self, lucene_query_string):
+        query_string = 'event.created:[now-%im TO now] AND %s' % (self.minutes_since, lucene_query_string)
+        body = dict(query=dict(query_string=dict(query=query_string)))
+        resp = requests.post('%s/%s/_search' % (self.es_host, self.index_pattern),
+                             params=dict(size=self.result_size),
+                             json=body)
+        resp.raise_for_status()
+        return resp.json().get('hits', {}).get('hits', [])
+
+    def start(self):
+        while True:
+            try:
+                print('[*] Sending beacon for %s' % (self.paw,))
+                beacon = self._send_beacon()
+                sleep = self._handle_instructions(beacon)
+                time.sleep(sleep)
+            except Exception as e:
+                print('[-] Operation loop error: %s' % e)
+                traceback.print_exc()
+                time.sleep(30)
+
+    """ PRIVATE """
+
+    def _handle_instructions(self, beacon):
+        self._profile['paw'] = beacon['paw']
+        for instruction in json.loads(beacon['instructions']):
+            result, seconds = self._execute_instruction(json.loads(instruction))
+            self._send_beacon(results=[result])
+            time.sleep(seconds)
+        else:
+            self._send_beacon()
+        return beacon['sleep']
+
+    def _next_instructions(self, beacon):
+        return json.loads(self._decode_bytes(beacon['instructions']))
+
+    def _send_beacon(self, results=None):
+        results = results if results else []
+        beacon = self.get_profile()
+        beacon['results'] = results
+        body = self._encode_string(json.dumps(beacon))
+        resp = requests.post('%s/beacon' % (self.server,), data=body)
+        resp.raise_for_status()
+        return json.loads(self._decode_bytes(resp.text))
+
+    def _execute_instruction(self, i):
+        print('[+] Running instruction: %s' % i['id'])
+        query = self._decode_bytes(i['command'])
+        results = self.execute_lucene_query(query)
+        return dict(output=self._encode_string(json.dumps(results)), pid=os.getpid(), status=0, id=i['id']), i['sleep']
+
+    @staticmethod
+    def _decode_bytes(s):
+        return b64decode(s).decode('utf-8', errors='ignore').replace('\n', '')
+
+    @staticmethod
+    def _encode_string(s):
+        return str(b64encode(s.encode()), 'utf-8')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--server', default='http://127.0.0.1:8888', help='Base URL  Caldera server.')
+    parser.add_argument('--es-host', default='http://127.0.0.1:9200', dest='es_host',
+                        help='Base URL of ElasticSearch.')
+    parser.add_argument('--index', default='*', help='ElasticSearch index pattern to search over.')
+    parser.add_argument('--group', default='blue')
+    parser.add_argument('--minutes-since', dest='minutes_since', default=60, type=int,
+                        help='How many minutes back to search for events.')
+    args = parser.parse_args()
+    try:
+        OperationLoop(args.server, es_host=args.es_host, index_pattern=args.index, group=args.group,
+                      minutes_since=args.minutes_since).start()
+    except Exception as e:
+        print('[-] Caldera server not be accessible, or: %s' % e)

--- a/payloads/elasticat.py
+++ b/payloads/elasticat.py
@@ -77,7 +77,7 @@ class OperationLoop:
         return json.loads(self._decode_bytes(beacon['instructions']))
 
     def _send_beacon(self, results=None):
-        results = results if results else []
+        results = results or []
         beacon = self.get_profile()
         beacon['results'] = results
         body = self._encode_string(json.dumps(beacon))

--- a/payloads/elasticat.py
+++ b/payloads/elasticat.py
@@ -3,7 +3,6 @@ import copy
 import json
 import os
 import platform
-import subprocess
 import socket
 import time
 import traceback


### PR DESCRIPTION
Changes:
- adds a new agent (elasticat) that executes elasticsearch queries for blue
- add ability to search for un-obfuscated powershell execution. This ability assumes ElasticSearch 7 with sysmon data and default mappings (ElasticSearch Common Schema) coming from winlogbeat -- we should maybe pick an elasticsearch configuration to standardize our abilities on... 

Related PR: 
- https://github.com/mitre/caldera/pull/1784 <-- merging this will help prevent annoying race conditions when the blue operation is run in auto-close mode

Notes:
- ~~there is sometimes issues with displaying results in the UI -- this isn't a problem here, but is due to core Caldera's front-end fact highlighting code breaking on certain special characters (I thought https://github.com/mitre/caldera/pull/1752 fixed it, but noticed other issues today)~~
- the new agent is python and based on ragdoll.py 
- the agent's queries uses requests, but we could further enhance using the python elasticsearch client and or the elasticsearch_dsl library
- ~~I didn't write any parsers -- it's still a bit up in the air if we want to use these to tie information into the gameboard or how we want to tie these results into other response abilities~~ This adds a new Sysmon + ECS (ElasticSearch Common Schema) parser
- while these queries could be theoretically be executed via sandcat, I thought a new agent made more sense for a few reasons
  - it's not necessarily a good idea to have responder agents on potentially compromised endpoints performing these queries (usually they wouldn't be able to as analysis networks are frequently segmented away from corporate prod networks)
  - adding an 'elasticsearch' as an execution platform is a nice way of restricting execution and making sure it only goes to capable agent
  - elasticsearch requires some additional parameters that would have been awkward to insert using facts or a separate config file (es address, index pattern, time interval, response size), but as its own agent these can be based via CLI.  These options can be enhanced later to support different kinds of auth, multiple es endpoints, etc. 
  - As a separate agent, this allows flexibility in where it's deployed (e.g. the thing that does the querying needs to have access to both elasticsearch and the caldera server which could be tricky depending on how flat the network is). 