### PR TITLE
VIRTS1661: start-time and end-time CLI arguments for elasticat

### DIFF
--- a/payloads/elasticat.py
+++ b/payloads/elasticat.py
@@ -158,7 +158,8 @@ if __name__ == '__main__':
     parser.add_argument('--end-time', dest='end_time', default='now', type=valid_date_format,
                         help='Date to stop searching for events. Must be accompanied by a --start-time.')
     parser.add_argument('--minutes-since', dest='minutes_since', default=60, type=int,
-                        help='How many minutes back to search for events.')
+                        help='How many minutes back to search for events. This argument will be ignored if --start-time'
+                             ' is provided.')
     parser.add_argument('--sleep', default=15, type=int,
                         help='Number of seconds to wait to check for new commands.')
     parser.add_argument('--result-size', default=10, type=int, dest='result_size',


### PR DESCRIPTION
Example commands and resulting queries:

elasticat.py --start-time 'Nov 18 2020 7:30 PM'
```
event.created:[2020-11-18T19:30:00Z TO now] AND process.name:powershell.exe AND process.args:*Bypass* AND process.args:*ExecutionPolicy*
```
elasticat.py --start-time 2020-11-18T19:30:00Z --end-time 2020-11-18T19:31:00Z
```
event.created:[2020-11-18T19:30:00Z TO 2020-11-18T19:31:00Z] AND process.name:powershell.exe AND process.args:*Bypass* AND process.args:*ExecutionPolicy*
```

Only odd behavior to note might be that in keeping the default=60 for `minutes-since`, it's possible to run elasticat with both `start-time` and `minutes-since` arguments like: `elasticat.py --start-time 2020-11-18T19:30:00Z --minutes-since 60` with no error to the user. On the backend however, elasticat will always prioritize `start-time` if it's provided, ignoring any `minutes-since` input. I've also added a message printed to the user after the Elasticsearch connection check indicating the time frame to be queried.