### PR TITLE
[VIRTS-1964] Ability Storage

### DIFF
--- a/app/response_svc.py
+++ b/app/response_svc.py
@@ -18,8 +18,8 @@ from plugins.response.app.c_processtree import ProcessTree
 async def process_elasticsearch_result(data, services):
     operation = await services.get('app_svc').find_op_with_link(data['link_id'])
     if hasattr(operation, 'chain'):
-        link = next(filter(lambda l: l.id == data['link_id'], operation.chain))
-        if link.ability.executor == 'elasticsearch':
+        link = next(filter(lambda l: str(l.id) == data['link_id'], operation.chain))
+        if link.executor.name == 'elasticsearch':
             await services.get('response_svc').process_elasticsearch_results(operation, link)
 
 

--- a/app/response_svc.py
+++ b/app/response_svc.py
@@ -18,7 +18,7 @@ from plugins.response.app.c_processtree import ProcessTree
 async def process_elasticsearch_result(data, services):
     operation = await services.get('app_svc').find_op_with_link(data['link_id'])
     if hasattr(operation, 'chain'):
-        link = next(filter(lambda l: str(l.id) == data['link_id'], operation.chain))
+        link = next(filter(lambda l: l.id == data['link_id'], operation.chain))
         if link.executor.name == 'elasticsearch':
             await services.get('response_svc').process_elasticsearch_results(operation, link)
 


### PR DESCRIPTION
## Description

Implements https://github.com/mitre/caldera/pull/2120

- Check link executor name from executor, not ability
- Hack to force link ID to string for comparison. Unsure why this wasn't working, but it may be resolved with the Link ID changes. (TKTK)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

See: https://github.com/mitre/caldera/pull/2120

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works