### PR TITLE
change to new ui and add endpoints

### DIFF
--- a/app/response_svc.py
+++ b/app/response_svc.py
@@ -65,6 +65,22 @@ class ResponseService(BaseService):
         await self._save_configurations()
         return web.json_response('complete')
 
+    async def adversaries(self, request):
+        adversaries = [a for a in await self.data_svc.locate('adversaries') if await a.which_plugin() == 'response']
+        await self.apply_adversary_config()
+        res = []
+        for adv in adversaries:
+            res.append({"adversary_id": adv.adversary_id, "name": adv.name})
+        return web.json_response(res)
+
+    async def responseAbilities(self, request):
+        abilities = [a for a in await self.data_svc.locate('abilities') if await a.which_plugin() == 'response']
+        await self.apply_adversary_config()
+        res = []
+        for ability in abilities:
+            res.append({"ability_id": ability.ability_id, "name": ability.name})
+        return web.json_response(res)
+
     @staticmethod
     async def register_handler(event_svc):
         await event_svc.observe_event(handle_link_completed, exchange='link', queue='completed')

--- a/app/response_svc.py
+++ b/app/response_svc.py
@@ -65,7 +65,7 @@ class ResponseService(BaseService):
         await self._save_configurations()
         return web.json_response('complete')
 
-    async def adversaries(self, request):
+    async def response_adversaries(self, request):
         adversaries = [a for a in await self.data_svc.locate('adversaries') if await a.which_plugin() == 'response']
         await self.apply_adversary_config()
         res = []
@@ -73,7 +73,7 @@ class ResponseService(BaseService):
             res.append({"adversary_id": adv.adversary_id, "name": adv.name})
         return web.json_response(res)
 
-    async def responseAbilities(self, request):
+    async def response_abilities(self, request):
         abilities = [a for a in await self.data_svc.locate('abilities') if await a.which_plugin() == 'response']
         await self.apply_adversary_config()
         res = []

--- a/app/response_svc.py
+++ b/app/response_svc.py
@@ -70,7 +70,7 @@ class ResponseService(BaseService):
         await self.apply_adversary_config()
         res = []
         for adv in adversaries:
-            res.append({"adversary_id": adv.adversary_id, "name": adv.name})
+            res.append(dict(adversary_id=adv.adversary_id, name=adv.name))
         return web.json_response(res)
 
     async def response_abilities(self, request):
@@ -78,7 +78,7 @@ class ResponseService(BaseService):
         await self.apply_adversary_config()
         res = []
         for ability in abilities:
-            res.append({"ability_id": ability.ability_id, "name": ability.name})
+            res.append(dict(ability_id=ability.ability_id, name=ability.name))
         return web.json_response(res)
 
     @staticmethod

--- a/app/response_svc.py
+++ b/app/response_svc.py
@@ -53,10 +53,8 @@ class ResponseService(BaseService):
 
     @template('response.html')
     async def splash(self, request):
-        abilities = [a for a in await self.data_svc.locate('abilities') if await a.which_plugin() == 'response']
-        adversaries = [a for a in await self.data_svc.locate('adversaries') if await a.which_plugin() == 'response']
         await self.apply_adversary_config()
-        return dict(abilities=abilities, adversaries=adversaries, auto_response=self.adversary)
+        return dict(auto_response=self.adversary)
 
     async def update_responder(self, request):
         data = dict(await request.json())

--- a/hook.py
+++ b/hook.py
@@ -14,8 +14,8 @@ async def enable(services):
     app = services.get('app_svc').application
     app.router.add_route('GET', '/plugin/responder/gui', response_svc.splash)
     app.router.add_route('POST', '/plugin/responder/update', response_svc.update_responder)
-    app.router.add_route('GET', '/plugin/responder/adversaries', response_svc.adversaries)
-    app.router.add_route('GET', '/plugin/responder/abilities', response_svc.responseAbilities)
+    app.router.add_route('GET', '/plugin/responder/adversaries', response_svc.response_adversaries)
+    app.router.add_route('GET', '/plugin/responder/abilities', response_svc.response_abilities)
 
     _register_agent('1837b43e-4fff-46b2-a604-a602f7540469')  # Elasticat agent
 

--- a/hook.py
+++ b/hook.py
@@ -14,6 +14,8 @@ async def enable(services):
     app = services.get('app_svc').application
     app.router.add_route('GET', '/plugin/responder/gui', response_svc.splash)
     app.router.add_route('POST', '/plugin/responder/update', response_svc.update_responder)
+    app.router.add_route('GET', '/plugin/responder/adversaries', response_svc.adversaries)
+    app.router.add_route('GET', '/plugin/responder/abilities', response_svc.responseAbilities)
 
     _register_agent('1837b43e-4fff-46b2-a604-a602f7540469')  # Elasticat agent
 

--- a/templates/response.html
+++ b/templates/response.html
@@ -47,7 +47,7 @@ function alpineResponse() {
     getAdversaries() {
       apiV2('GET', '/plugin/responder/adversaries').then((adversaries) => {
         this.adversaries = adversaries;
-        this.selectedAdversaryID = adversaries[0].adversary_id;
+        this.selectedAdversaryID = "{{auto_response.adversary_id}}";
         return apiV2('GET', '/plugin/responder/abilities').then((abilities) => {
           this.abilities = abilities;
         });

--- a/templates/response.html
+++ b/templates/response.html
@@ -1,49 +1,70 @@
-<div id="response" class="section-profile">
-    <div class="row">
-        <div class="topleft duk-icon"><img onclick="removeSection('response')" src="/gui/img/x.png"></div>
-        <div class="column section-border" style="flex:25%;text-align:left;padding:15px;">
-            <h1 style="font-size:70px;margin-top:-20px;">Response</h1>
-            <h4 style="margin-top:-40px">the autonomous incident responder</h4>
-            <p>
-                Think of <i>response</i> as the blue version of the stockpile plugin. Specific blue team response
-                actions are stored here as abilities. Instead of adversaries,you'll find defenders, which can be
-                launched on a host to protect it against an attacker.
-            </p>
-            <select id="auto-response-select">
-                {% for adv in adversaries %}
-                    {% if adv.adversary_id == auto_response.adversary_id %}
-                        <option id="auto-{{ adv.adversary_id }}" value="{{ adv.adversary_id }}" selected>{{ adv.name }}</option>
-                    {% else %}
-                        <option id="auto-{{ adv.adversary_id }}" value="{{ adv.adversary_id }}">{{ adv.name }}</option>
-                    {% endif %}
-                {% endfor %}
-            </select>
-            <button id="save-auto-response" type="button" class="button-success atomic-button" onclick="saveAutoResponse()">Save</button>
-        </div>
-        <div class="column" style="flex:75%">
-            <div class="column" style="flex:67%;padding:15px;text-align: left">
-                <div class="row inner-row" style="background-color: inherit;margin: -45px -50px -50px;">
-                    <div class="column duk-home" style="flex:33%;border-right: solid white 1px;line-height: 10px;">
-                        <img src="/gui/img/payload.png"/>
-                        <h3><span style="color:lightblue;font-weight: 900;">abilities</span></h3>
-                        <h1>{{ abilities|length }}</h1>
-                    </div>
-                    <div class="column duk-home" style="flex:33%;line-height: 10px;">
-                        <img src="/gui/img/hacker.png"/>
-                        <h3><span style="color:green;font-weight: 900;">defenders</span></h3>
-                        <h1>{{ adversaries|length }}</h1>
-                    </div>
-                </div>
-            </div>
-        </div>
+<div x-data="alpineResponse" x-init="getAdversaries()" id="response" class="section-profile">
+  <div class="row">
+    <div class="topleft duk-icon"><img onclick="removeSection('response')" src="/gui/img/x.png"></div>
+    <div class="column section-border" style="flex:25%;text-align:left;padding:15px;">
+      <h1 style="font-size:70px;margin-top:-20px;">Response</h1>
+      <h4 style="margin-top:-40px">the autonomous incident responder</h4>
+      <p>
+        Think of <i>response</i> as the blue version of the stockpile plugin. Specific blue team response
+        actions are stored here as abilities. Instead of adversaries,you'll find defenders, which can be
+        launched on a host to protect it against an attacker.
+      </p>
+      <select x-model="selectedAdversaryID" id="auto-response-select">
+        <template x-for="adversary in adversaries" :key="adversary.adversary_id">
+          <option x-bind:value="adversary.adversary_id" x-text="adversary.name" />
+        </template>
+      </select>
+      <button id="save-auto-response" type="button" class="button-success atomic-button" x-on:click="saveAutoResponse()">Save</button>
     </div>
+    <div class="column" style="flex:75%">
+      <div class="column" style="flex:67%;padding:15px;text-align: left">
+        <div class="row inner-row" style="background-color: inherit;margin: -45px -50px -50px;">
+          <div class="column duk-home" style="flex:33%;border-right: solid white 1px;line-height: 10px;">
+            <img src="/gui/img/payload.png"/>
+            <h3><span style="color:lightblue;font-weight: 900;">abilities</span></h3>
+            <h1 x-text="abilities.length"> </h1>
+          </div>
+          <div class="column duk-home" style="flex:33%;line-height: 10px;">
+            <img src="/gui/img/hacker.png"/>
+            <h3><span style="color:green;font-weight: 900;">defenders</span></h3>
+            <h1 x-text="adversaries.length"></h1>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
+
 <script>
-    function saveAutoResponse() {
-        function streamUpdate() {
-            stream('Auto responder has been updated');
-        }
-        restRequest('POST', {'adversary_id': $('#auto-response-select').val()}, streamUpdate, '/plugin/responder/update');
+
+function alpineResponse() {
+  return {
+    adversaries: [],
+    selectedAdversaryID: '',
+    abilities: [],
+
+    getAdversaries() {
+      apiV2('GET', '/plugin/responder/adversaries').then((adversaries) => {
+        this.adversaries = adversaries;
+        this.selectedAdversaryID = adversaries[0].adversary_id;
+        return apiV2('GET', '/plugin/responder/abilities').then((abilities) => {
+          this.abilities = abilities;
+        });
+      }).catch((error) => {
+          toast('Error getting adversaries', false);
+          console.error(error);
+        })
+    },
+
+    saveAutoResponse(){
+      apiV2('POST', '/plugin/responder/update', {'adversary_id': this.selectedAdversaryID}).then((res) => {
+        toast("Saved Response!", true);
+      }).catch((error) => {
+          toast("Error saving response", false);
+          console.error(error);
+        });
     }
+  }
+}
 </script>


### PR DESCRIPTION
## Description

This PR updates the UI to alpine. Additionally, the old UI accessed the adversaries and abilities by serving them with jinja templating. This PR exposes two new endpoints, `/plugin/response/adversaries` and `/plugin/response/abilities` and they are fetched on the front-end. If this isn't desirable I can remove the endpoints and continue to serve the adversaries/abilities with the template. Finally, I added a toast when the user successfully saves a response.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Compared the new UI and old UI to make sure they look the same and have the same functionality. Saved multiple responses with no trouble.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
