### PR TITLE
Address Copilot review feedback from CVE fix PR #80

### DIFF
--- a/payloads/elasticat.py
+++ b/payloads/elasticat.py
@@ -14,6 +14,10 @@ from dateutil import parser as date_parser
 import requests
 import requests.auth
 
+HEALTH_CHECK_TIMEOUT = 30
+QUERY_TIMEOUT = 60
+BEACON_TIMEOUT = 60
+
 
 class OperationLoop:
 
@@ -55,7 +59,7 @@ class OperationLoop:
         return self._profile.get('paw', 'unknown')
 
     def test_elastic_connection(self):
-        resp = requests.get('%s/_cat/health' % (self.es_host,), params=dict(format='json'), auth=self.auth, timeout=30)
+        resp = requests.get('%s/_cat/health' % (self.es_host,), params=dict(format='json'), auth=self.auth, timeout=HEALTH_CHECK_TIMEOUT)
         resp.raise_for_status()
         print("[*] Connection to Elasticsearch OK. %s" % resp.json())
 
@@ -69,7 +73,7 @@ class OperationLoop:
         execution_timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         resp = requests.post('%s/%s/_search' % (self.es_host, self.index_pattern),
                              params=dict(size=self.result_size),
-                             json=body, auth=self.auth, timeout=60)
+                             json=body, auth=self.auth, timeout=QUERY_TIMEOUT)
         resp.raise_for_status()
         return resp.json().get('hits', {}).get('hits', []), execution_timestamp
 
@@ -109,7 +113,7 @@ class OperationLoop:
         beacon = self.get_profile()
         beacon['results'] = results
         body = self._encode_string(json.dumps(beacon))
-        resp = requests.post('%s/beacon' % (self.server,), data=body, timeout=60)
+        resp = requests.post('%s/beacon' % (self.server,), data=body, timeout=BEACON_TIMEOUT)
         resp.raise_for_status()
         beacon_resp = json.loads(self._decode_bytes(resp.text))
         self._profile['paw'] = beacon_resp['paw']


### PR DESCRIPTION
## Summary
Follow-up to PR #80 addressing Copilot code review suggestions:

- Extract timeout magic numbers into named constants: `HEALTH_CHECK_TIMEOUT = 30`, `QUERY_TIMEOUT = 60`, `BEACON_TIMEOUT = 60`
- Replace all hardcoded timeout values in `elasticat.py` with the corresponding constants

## Test plan
- [ ] Verify elasticat health check, query, and beacon operations use correct timeout values
- [ ] Confirm no remaining magic number timeouts in elasticat.py